### PR TITLE
add the ability for futures to know about global and group slot numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "future-queue"
 version = "0.3.0"
 dependencies = [
+ "debug-ignore",
  "fnv",
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["asynchronous"]
 keywords = ["stream", "futures", "async", "buffer_unordered"]
 
 [dependencies]
+debug-ignore = "1.0.5"
 fnv = "1.0.7"
 futures-util = { version = "0.3.31", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.15"

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -1,0 +1,158 @@
+// Copyright (c) The future-queue Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{cmp::Reverse, collections::BinaryHeap};
+
+/// A model for slot indexes currently in use.
+///
+/// The semantics are:
+///
+/// * When `reserve` is called, a new slot is assigned. The slot is the smallest
+///   number possible.
+/// * Slots are reserved until `release` is called, at which point the slot is
+///   available for reuse.
+///
+/// `SlotReservations` is implemented via a simple heap.
+#[derive(Debug)]
+pub(crate) struct SlotReservations {
+    next: u64,
+    // BinaryHeap is a max-heap, but we care about the smallest slot: use
+    // Reverse to turn it into a min-heap.
+    free: BinaryHeap<Reverse<u64>>,
+    check_reserved: bool,
+}
+
+impl SlotReservations {
+    /// Create a new `SlotReservations` with no slots reserved.
+    #[allow(unused)]
+    pub(crate) fn new() -> Self {
+        Self {
+            next: 0,
+            free: BinaryHeap::new(),
+            check_reserved: false,
+        }
+    }
+
+    /// Create a new `SlotReservations` with an initial free-heap capacity
+    /// allocated.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            next: 0,
+            free: BinaryHeap::with_capacity(capacity),
+            check_reserved: false,
+        }
+    }
+
+    /// Set the `check_reserved` flag: useful for testing.
+    pub(crate) fn set_check_reserved(&mut self, check_reserved: bool) {
+        self.check_reserved = check_reserved;
+    }
+
+    /// Reserve a new slot.
+    #[inline]
+    pub(crate) fn reserve(&mut self) -> u64 {
+        if let Some(slot) = self.free.pop() {
+            slot.0
+        } else {
+            let slot = self.next;
+            self.next += 1;
+            slot
+        }
+    }
+
+    /// Release a slot.
+    ///
+    /// This does not check if the slot is reserved by default. But it does if
+    /// [`Self::set_check_reserved`] is called.
+    #[inline]
+    pub(crate) fn release(&mut self, slot: u64) {
+        if self.check_reserved {
+            assert!(self.check_reserved(slot), "slot {slot} is reserved");
+        }
+        self.free.push(Reverse(slot));
+    }
+
+    /// Check if a slot is reserved.
+    #[must_use]
+    pub(crate) fn check_reserved(&self, slot: u64) -> bool {
+        if slot >= self.next {
+            return false;
+        }
+        if self.free.iter().any(|s| s.0 == slot) {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_in_order() {
+        let mut slots = SlotReservations::new();
+        slots.set_check_reserved(true);
+        assert_reserved(&slots, &[]);
+
+        let slot1 = slots.reserve();
+        assert_eq!(slot1, 0);
+        assert_reserved(&slots, &[0]);
+
+        let slot2 = slots.reserve();
+        assert_eq!(slot2, 1);
+        assert_reserved(&slots, &[0, 1]);
+
+        slots.release(slot1);
+        assert_reserved(&slots, &[1]);
+        slots.release(slot2);
+        assert_reserved(&slots, &[]);
+
+        assert_eq!(slots.reserve(), 0);
+        assert_reserved(&slots, &[0]);
+
+        assert_eq!(slots.reserve(), 1);
+        assert_reserved(&slots, &[0, 1]);
+    }
+
+    #[test]
+    fn release_out_of_order() {
+        let mut slots = SlotReservations::new();
+        slots.set_check_reserved(true);
+        assert_reserved(&slots, &[]);
+
+        let slot1 = slots.reserve();
+        assert_eq!(slot1, 0);
+        assert_reserved(&slots, &[0]);
+
+        let slot2 = slots.reserve();
+        assert_eq!(slot2, 1);
+        assert_reserved(&slots, &[0, 1]);
+
+        slots.release(slot2);
+        assert_reserved(&slots, &[0]);
+
+        slots.release(slot1);
+        assert_reserved(&slots, &[]);
+
+        assert_eq!(slots.reserve(), slot1);
+        assert_reserved(&slots, &[0]);
+        assert_eq!(slots.reserve(), slot2);
+        assert_reserved(&slots, &[0, 1]);
+    }
+
+    fn assert_reserved(slots: &SlotReservations, expected: &[u64]) {
+        for &slot in expected {
+            assert!(slots.check_reserved(slot), "slot {} is not reserved", slot);
+        }
+
+        // Also check slots from max to 64 or so to make sure they are not reserved.
+        for slot in (expected.iter().max().map_or(0, |max| max + 1))..64 {
+            assert!(
+                !slots.check_reserved(slot),
+                "slot {slot} is not reserved (slots: {slots:?})",
+            );
+        }
+    }
+}


### PR DESCRIPTION
With this change, called futures can now be assigned an integer that is unique for the lifetime of the future. The integer is always the smallest possible that could be assigned.

Also expand our property-based testing to ensure uniqueness and compactness of slots.